### PR TITLE
estimateRA

### DIFF
--- a/R/plot_bbdml.R
+++ b/R/plot_bbdml.R
@@ -8,6 +8,7 @@
 #' @param title (Optional). Default \code{NULL}. Character string. The main title for the graphic.
 #' @param B (Optional). Default \code{1000}. Integer. Number of bootstrap simulations for prediction intervals. Use \code{B = 0} for no prediction intervals.
 #' @param sample_names (Optional). Default \code{TRUE}. Boolean. If \code{FALSE}, remove sample names from the plot.
+#' @param data_only (Optional). Do not plot, only return data. Defaults to FALSE.
 #' @param ... There are no optional parameters at this time.
 #'
 #' @return Object of class \code{ggplot}. Plot of \code{bbdml} model fit with 95% prediction intervals.
@@ -24,7 +25,7 @@
 #' plot(mod, color = "DayAmdmt")
 #' }
 #' @export
-plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NULL, title = NULL, B = 1000, sample_names = TRUE, ...) {
+plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NULL, title = NULL, B = 1000, sample_names = TRUE, data_only = FALSE,...) {
   # input <- match.call(expand.dots = TRUE)
   mod <- x
 
@@ -70,6 +71,8 @@ plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NUL
                       ymin = ymin,
                       ymax = ymax
   )
+
+  if (!(data_only == TRUE)) {
 
   my_ord_str <- ""
   custom_color <- custom_shape <- FALSE
@@ -137,4 +140,7 @@ plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NUL
     my_gg <- my_gg + ggplot2::theme(axis.text.x = ggplot2::element_blank())
   }
   my_gg
+  } else {
+    return(df)
+  }
 }

--- a/R/plot_differentialTest.R
+++ b/R/plot_differentialTest.R
@@ -2,6 +2,7 @@
 #'
 #' @param x Object of class \code{differentialTest}
 #' @param level (Optional). Character vector. Desired taxonomic levels for taxa labels.
+#' @param data_only (Optional). Do not plot, only return data. Defaults to FALSE.
 #' @param ... No optional arguments are accepted at this time.
 #'
 #'
@@ -25,7 +26,7 @@
 #' }
 #'
 #' @export
-plot.differentialTest <- function(x, level = NULL, ...) {
+plot.differentialTest <- function(x, level = NULL, data_only = FALSE, ...) {
   signif_taxa <- x$significant_taxa
   if ("phyloseq" %in% class(x$data)) {
     if (!is.null(x$data@tax_table)) {
@@ -66,6 +67,7 @@ plot.differentialTest <- function(x, level = NULL, ...) {
         count <- count + 1
       }
     }
+    if (!(data_only == TRUE)) {
     # global variables warning suppression
     taxa <- xmin <- xmax <- NULL
 
@@ -80,5 +82,12 @@ plot.differentialTest <- function(x, level = NULL, ...) {
       ggplot2::scale_y_discrete(limits = rev(df$taxa)) +
       ggplot2::scale_x_continuous(breaks = scales::pretty_breaks(n = 5)) +
       ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1))
+    } else {
+    return(df)
+  }
+  } else {
+    message("No taxa were found to be significantly different. ")
+    message("This is unusual. ")
+    stop("Please verify that your formulas are correctly specified. ")
   }
 }

--- a/R/summary_bbdml.R
+++ b/R/summary_bbdml.R
@@ -21,7 +21,9 @@
 summary.bbdml <- function(object, ...) {
   # For now, Wald test
   coef.table <- waldt(object)
-  keep <- match(c("call", "df.model", "df.residual", "logL", "link", "phi.link", "formula", "phi.formula", "np.mu", "np.phi", "sep_da", "sep_dv"),
+  # keep <- match(c("call", "df.model", "df.residual", "logL", "link", "phi.link", "formula", "phi.formula", "np.mu", "np.phi", "sep_da", "sep_dv"),
+  #               names(object), 0L)
+  keep <- match(c("call", "df.model", "df.residual", "logL", "link", "phi.link", "formula", "phi.formula", "np.mu", "np.phi", "sep_da", "sep_dv", "mu.resp", "phi.resp"),
                 names(object), 0L)
   ans <- c(object[keep],
            list(coefficients = coef.table))


### PR DESCRIPTION
I would like to suggest a couple of tweaks intended to make it easier for users to access certain results that are/may be useful. 

- The first commit is to make the estimates for mu and phi carry over through the `summary.bbdml` function. This makes the estimated/fitted relative abundances accessible from within a `differentialTest-class` object. 
- The two other commits added a parameter (`data_only`) to the two plotting functions (`plot.bbdml`, `plot.differentialTest`) which allows a user to ask the function to return the data instead of a plot of the data. 