### PR TITLE
CRAN problem fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: corncob
 Title: Count Regression for Correlated Observations with the Beta-Binomial
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Bryan D", "Martin", email = "bmartin6@uw.edu", role = c("aut", "cre")),
     person("Daniela", "Witten", email = "dwitten@uw.edu", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ License: GPL (>= 2)
 Imports: stats, utils, optimr, VGAM, numDeriv, Matrix, ggplot2, trust, dplyr, magrittr, rmutil, detectseparation, scales, phyloseq
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: knitr,
     rmarkdown,
     testthat,

--- a/R/plot_bbdml.R
+++ b/R/plot_bbdml.R
@@ -130,7 +130,7 @@ plot.bbdml <- function(x, total = FALSE, color = NULL, shape = NULL, facet = NUL
     ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1))
 
   if (custom_color) {
-    my_gg <- my_gg + ggplot2::guides(colour = FALSE)
+    my_gg <- my_gg + ggplot2::guides(colour = "none")
   }
   if (custom_shape) {
     my_gg <- my_gg + ggplot2::scale_shape_identity()

--- a/man/differentialTest.Rd
+++ b/man/differentialTest.Rd
@@ -24,6 +24,7 @@ differentialTest(
   inits = NULL,
   inits_null = NULL,
   try_only = NULL,
+  verbose = FALSE,
   ...
 )
 }
@@ -65,6 +66,8 @@ differentialTest(
 \item{inits_null}{Optional initializations for model fit using \code{formula_null} and \code{phi.formula_null} as rows of a matrix. Defaults to \code{NULL}.}
 
 \item{try_only}{Optional numeric. Will try only the \code{try_only} taxa, specified either via numeric input or character taxa names. Useful for speed when troubleshooting. Defaults to \code{NULL}, testing all taxa.}
+
+\item{verbose}{Boolean. Defaults to \code{FALSE}; print status updates for long-running analyses}
 
 \item{...}{Optional additional arguments for \code{\link{bbdml}}}
 }

--- a/tests/testthat/test_bbdml.R
+++ b/tests/testthat/test_bbdml.R
@@ -78,6 +78,10 @@ test_that("checking for perfectly discriminant", {
                        nstart = 1))
   expect_output(expect_warning(print(tmp)))
   expect_output(expect_warning(print(summary(tmp))))
+  expect_true(tmp$sep_da) # confirm separation detected
+  expect_true(tmp$sep_dv)
+  expect_false(out_bad_init$sep_da) # sanity check comparison, no separation
+
   expect_warning(bbdml(formula = cbind(W, M - W) ~ 1,
                        phi.formula = ~ X1,
                        data = test_data_bad,

--- a/tests/testthat/test_differentialTest.R
+++ b/tests/testthat/test_differentialTest.R
@@ -25,13 +25,24 @@ temp2 <- differentialTest(formula = ~ Plants + DayAmdmt,
                          inits = rbind(rep(.01, 6)),
                          inits_null = rbind(rep(0.01, 2)))
 
-temp3 <- differentialTest(formula = ~ Plants + DayAmdmt,
-                         phi.formula = ~ Plants + DayAmdmt,
-                         formula_null = ~ 1,
-                         phi.formula_null = ~ 1,
-                         data = subsoil_disc, boot = FALSE, test = "LRT",
-                         inits = rbind(rep(.01, 6)),
-                         inits_null = rbind(rep(0.01, 2)))
+temp3 <- suppressWarnings(
+  differentialTest(formula = ~ Plants + DayAmdmt,
+                   phi.formula = ~ Plants + DayAmdmt,
+                   formula_null = ~ 1,
+                   phi.formula_null = ~ 1,
+                   data = subsoil_disc, boot = FALSE, test = "LRT",
+                   inits = rbind(rep(.01, 6)),
+                   inits_null = rbind(rep(0.01, 2)))
+  # Record of expected warnings below #
+
+  # Warning in print.bbdml(mod) :
+  # This model is based on a discriminant taxa.
+  # You may see NAs in the model summary because Wald testing is invalid.
+  # Likelihood ratio testing can be used, but valid standard errors cannot be calculated.
+
+  # Warning in waldt(object) :
+  # Singular Hessian! Cannot calculate p-values in this setting.
+)
 
 temp_badinits1 <- differentialTest(formula = ~ Plants + DayAmdmt,
                          phi.formula = ~ Plants + DayAmdmt,


### PR DESCRIPTION
Hi @bryandmartin 

Thanks for the great package. This pull request attempts to fix the problems that appear to have caused corncob's removal from CRAN.

The main problem appears to be caused by the cran release of detectseparation version 0.3 which changes the name of one of the elements in the list returned by detect_separation.

I ran devtools::check on my machine, and addressed another couple of warnings and notes too, in separate commits.
Hope this helps to get corncob back on cran 🙂 

cheers,
David